### PR TITLE
Refactor and test cases

### DIFF
--- a/programs/anchor-movie-review-program/src/lib.rs
+++ b/programs/anchor-movie-review-program/src/lib.rs
@@ -74,9 +74,8 @@ pub mod anchor_movie_review_program {
         movie_comment.review = ctx.accounts.movie_review.key();
         movie_comment.commenter = ctx.accounts.initializer.key();
         movie_comment.comment = comment;
-        movie_comment.count = movie_comment_counter.counter;
-
         movie_comment_counter.counter += 1;
+        movie_comment.count = movie_comment_counter.counter;
 
         mint_to(
             CpiContext::new_with_signer(

--- a/tests/anchor-movie-review-program.ts
+++ b/tests/anchor-movie-review-program.ts
@@ -92,11 +92,11 @@ describe("anchor-movie-review-program", () => {
       provider.wallet.publicKey
     )
 
-    let commentCounter = await program.account.movieCommentCounter.fetch(
+    const commentCounter = await program.account.movieCommentCounter.fetch(
       commentCounterPda
     )
 
-    let [commentPda] = anchor.web3.PublicKey.findProgramAddressSync(
+    const [commentPda] = anchor.web3.PublicKey.findProgramAddressSync(
       [
         movie_pda.toBuffer(),
         commentCounter.counter.toArrayLike(Buffer, "le", 8),


### PR DESCRIPTION
There was a bug where the first comment count was set to zero and then the counter account was being incremented.
Fix: Update the counter account and then use its value for updating the comment count.

All the test cases were bascially not checking anything as they only had expect () with equal()

Added expect statements in the test case for adding a comment.
